### PR TITLE
Directly write history if set options require it.

### DIFF
--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -114,6 +114,13 @@ function _per-directory-history-addhistory() {
       true
   else
       print -Sr -- "${1%%$'\n'}"
+      # instantly write history if set options require it.
+      if [[ -o share_history ]] || \
+         [[ -o inc_append_history ]] || \
+         [[ -o inc_append_history_time ]]; then
+          fc -AI $HISTFILE
+          fc -AI $_per_directory_history_directory
+      fi
       fc -p $_per_directory_history_directory
   fi
 }


### PR DESCRIPTION
This commit makes sure that the history is instantly written if one of
the following options are set:

* share_history
* inc_append_history
* inc_append_history_time

Closes #21